### PR TITLE
Add list & context workspace smoke test

### DIFF
--- a/test/extended/util/client.go
+++ b/test/extended/util/client.go
@@ -449,6 +449,16 @@ func (c *CLI) SetupWorkSpaceWithSpecificPath(serverURL string) {
 	e2e.Logf("Workspace %q has been fully provisioned.", c.currentWs.Name)
 }
 
+// ListWorkSpacesWithSpecificPath returns a list of WorkSpaces under a specific workspace
+func (c *CLI) ListWorkSpacesWithSpecificPath(serverURL string) []string {
+	workSpacesRaw, err := c.WithoutNamespace().WithoutKubeconf().Run("get").Args("workspaces", "-o", "jsonpath={.items[*]['metadata.name']}", "--server="+serverURL).Output()
+	o.Expect(err).NotTo(o.HaveOccurred())
+	if workSpacesRaw == "" {
+		return []string{}
+	}
+	return strings.Split(workSpacesRaw, " ")
+}
+
 // TeardownWorkSpace removes workspaces created by this test.
 func (c *CLI) TeardownWorkSpace() {
 	if len(c.configPath) > 0 {

--- a/test/extended/workspacetype/workspace.go
+++ b/test/extended/workspacetype/workspace.go
@@ -1,6 +1,8 @@
 package workspacetype
 
 import (
+	"fmt"
+	"strings"
 	"time"
 
 	g "github.com/onsi/ginkgo"
@@ -16,49 +18,101 @@ var _ = g.Describe("[sig-workspace]", func() {
 		k = exutil.NewCLIWithWorkSpace("kcp-workspace")
 	)
 
-	g.It("Author:pewang-Medium-[Smoke] Multi levels workspaces lifecycle should works well", func() {
-		g.By("# Create a test workspace under user home workspace should become ready to use")
+	g.It("Author:pewang-Medium-[Smoke] Multi levels workspaces lifecycle should work", func() {
+		g.By("# Create a test workspace as parent workspace")
 		k.SetupWorkSpace()
-		myWorkSpace := k.WorkSpace()
+		parentWorkSpace := k.WorkSpace()
 
-		g.By("# Create a child level workspace should become ready to use")
-		k.SetupWorkSpaceWithSpecificPath(myWorkSpace.ServerURL)
-		mySubWorkSpace := k.WorkSpace()
+		g.By("# Create five child workspaces under the parent workspace")
+		childWorkSpaces := []exutil.WorkSpace{}
+		for i := 1; i <= 5; i++ {
+			g.By(fmt.Sprintf("# Creating child workspace no.%v", i))
+			k.SetupWorkSpaceWithSpecificPath(parentWorkSpace.ServerURL)
+			childWorkSpace := k.WorkSpace()
+			childWorkSpaces = append(childWorkSpaces, childWorkSpace)
+		}
 
-		g.By("# From the home workspace could get the test workspace but couldn't get its child level workspace")
-		output, err := k.WithoutNamespace().WithoutKubeconf().WithoutWorkSpaceServer().Run("get").Args("--server="+myWorkSpace.ParentServerURL, "workspace").Output()
+		g.By(`# Check list workspaces command returns all columns`)
+		output, err := k.Run("get").Args("--server="+parentWorkSpace.ParentServerURL, "workspace").Output()
 		o.Expect(err).NotTo(o.HaveOccurred())
 		o.Expect(output).Should(o.And(
-			o.ContainSubstring(myWorkSpace.Name),
-			o.ContainSubstring(myWorkSpace.ServerURL),
-		))
-		o.Expect(output).ShouldNot(o.ContainSubstring(mySubWorkSpace.Name))
-
-		g.By("# From the test workspace could get its child workspace")
-		output, err = k.WithoutNamespace().WithoutKubeconf().WithoutWorkSpaceServer().Run("get").Args("--server="+myWorkSpace.ServerURL, "workspace").Output()
-		o.Expect(err).NotTo(o.HaveOccurred())
-		o.Expect(output).Should(o.And(
-			o.ContainSubstring(mySubWorkSpace.Name),
-			o.ContainSubstring(mySubWorkSpace.ServerURL),
+			o.ContainSubstring("NAME"),
+			o.ContainSubstring("TYPE"),
+			o.ContainSubstring("PHASE"),
+			o.ContainSubstring("URL"),
 		))
 
-		g.By("# Delete the child workspace and the test workspace should be successful")
-		// Delete the child workspace and check it deleted successfully
-		output, err = k.WithoutNamespace().WithoutKubeconf().WithoutWorkSpaceServer().Run("delete").Args("--server="+myWorkSpace.ServerURL, "workspace", mySubWorkSpace.Name).Output()
+		g.By(`# From the home workspace, I can list only the test "parent workspace" but cannot list the five "child workspaces"`)
+		homeSubWorkSpaces := k.ListWorkSpacesWithSpecificPath(parentWorkSpace.ParentServerURL)
+		// NOTE: use ContainSubstring as a workaround to WorkSpace name inequality bug: https://url.corp.redhat.com/1878a60
+		homeSubWorkSpacesString := strings.Join(homeSubWorkSpaces, ",")
+		o.Expect(homeSubWorkSpacesString).Should(o.ContainSubstring(parentWorkSpace.Name))
+		for _, childWorkSpace := range childWorkSpaces {
+			o.Expect(homeSubWorkSpacesString).ShouldNot(o.ContainSubstring(childWorkSpace.Name))
+		}
+
+		g.By("# From parent workspace, I can list its child workspaces")
+		parentSubWorkSpaces := k.ListWorkSpacesWithSpecificPath(parentWorkSpace.ServerURL)
+		// NOTE: use ContainSubstring as a workaround to WorkSpace name inequality bug: https://url.corp.redhat.com/1878a60
+		parentSubWorkSpacesString := strings.Join(parentSubWorkSpaces, ",")
+		for _, childWorkSpace := range childWorkSpaces {
+			o.Expect(parentSubWorkSpacesString).Should(o.ContainSubstring(childWorkSpace.Name))
+		}
+
+		g.By("# Delete child workspaces")
+		for _, childWorkSpace := range childWorkSpaces {
+			output, err := k.Run("delete").Args("--server="+parentWorkSpace.ServerURL, "workspace", childWorkSpace.Name).Output()
+			o.Expect(err).NotTo(o.HaveOccurred())
+			o.Expect(output).Should(o.ContainSubstring("deleted"))
+			o.Eventually(func() string {
+				workSpaces, _ := k.Run("get").Args("--server="+parentWorkSpace.ServerURL, "workspace").Output()
+				return workSpaces
+			}, 60*time.Second, 5*time.Second).ShouldNot(o.ContainSubstring(childWorkSpace.Name))
+		}
+
+		g.By("# Delete parent workspace")
+		output, err = k.Run("delete").Args("--server="+parentWorkSpace.ParentServerURL, "workspace", parentWorkSpace.Name).Output()
 		o.Expect(err).NotTo(o.HaveOccurred())
 		o.Expect(output).Should(o.ContainSubstring("deleted"))
 		o.Eventually(func() string {
-			workSpaces, _ := k.WithoutNamespace().WithoutKubeconf().WithoutWorkSpaceServer().Run("get").Args("--server="+myWorkSpace.ServerURL, "workspace").Output()
+			workSpaces, _ := k.Run("get").Args("--server="+parentWorkSpace.ParentServerURL, "workspace").Output()
 			return workSpaces
-		}, 60*time.Second, 5*time.Second).ShouldNot(o.ContainSubstring(mySubWorkSpace.Name))
+		}, 60*time.Second, 5*time.Second).ShouldNot(o.ContainSubstring(parentWorkSpace.Name))
+	})
 
-		// Delete the test workspace under home workspace and check it deleted successfully
-		output, err = k.WithoutNamespace().WithoutKubeconf().WithoutWorkSpaceServer().Run("delete").Args("--server="+myWorkSpace.ParentServerURL, "workspace", myWorkSpace.Name).Output()
+	// author: zxiao@redhat.com
+	g.It("Author:zxiao-Medium-[Serial] I can create context for a specific workspace and use it", func() {
+		g.By("# Create a test workspace")
+		k.SetupWorkSpace()
+		workSpace := k.WorkSpace()
+
+		g.By("# Get context before test run")
+		contextBeforeTestRun, err := k.Run("config").Args("current-context").Output()
 		o.Expect(err).NotTo(o.HaveOccurred())
-		o.Expect(output).Should(o.ContainSubstring("deleted"))
-		o.Eventually(func() string {
-			workSpaces, _ := k.WithoutNamespace().WithoutKubeconf().WithoutWorkSpaceServer().Run("get").Args("--server="+myWorkSpace.ParentServerURL, "workspace").Output()
-			return workSpaces
-		}, 60*time.Second, 5*time.Second).ShouldNot(o.ContainSubstring(myWorkSpace.Name))
+
+		g.By("# Create context under this workspace")
+		err = k.WithoutNamespace().WithoutKubeconf().WithoutWorkSpaceServer().Run("kcp").Args("workspace", "create-context", workSpace.Name, "--server="+workSpace.ParentServerURL).Execute()
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("# Switch to the newly created context")
+		// NOTE: not doing assertion as to avoid double assertion failures, use DeferCleanup in ginkgo v2.0 in the future
+		defer func() {
+			err = k.Run("config").Args("use-context", contextBeforeTestRun).Execute()
+			o.Expect(err).NotTo(o.HaveOccurred())
+			k.Run("config").Args("delete-context", workSpace.Name).Execute()
+		}()
+
+		err = k.Run("config").Args("use-context", workSpace.Name).Execute()
+		o.Expect(err).NotTo(o.HaveOccurred())
+
+		g.By("# Check current context name")
+		currentContext, err := k.Run("config").Args("current-context").Output()
+		o.Expect(err).NotTo(o.HaveOccurred())
+		o.Expect(currentContext).To(o.Equal(workSpace.Name))
+
+		g.By("# Recreate context, expect to show conflict")
+		output, err := k.WithoutNamespace().WithoutKubeconf().WithoutWorkSpaceServer().Run("kcp").Args("workspace", "create-context", workSpace.Name, "--server="+workSpace.ParentServerURL).Output()
+		o.Expect(err).To(o.HaveOccurred())
+		o.Expect(output).To(o.ContainSubstring("already exists in kubeconfig"))
 	})
 })


### PR DESCRIPTION
Hi @kasturinarra @wangke19 @Phaow, I added a smoke test cases related to the `kubectl get workspaces`and `kubectl kcp workspace create-context` command. Local test result:
```
passed: (52s) 2022-08-10T09:25:00 "[sig-workspace] Author:zxiao-Medium-I can list child workspaces under parent workspace [Smoke] [Suite:kcp/smoke/parallel/minimal]"

passed: (19.1s) 2022-08-11T03:43:57 "[sig-workspace] Author:zxiao-Medium-I can create context for a specific workspace and use it [Smoke][Serial] [Suite:kcp/smoke/serial/minimal]"
```
Please take a look if you have time. Thanks!