### PR TITLE
Fix client namespace functions

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -6,7 +6,7 @@ In order to make the `Golang` case running stable, please follow the below check
 - Please **clean up** the created resources no matter the case exits normal or not, the `Defer` is recommend.
 - These `Golang` cases running parallelly by default, please don't use common names for your resources.
 - The namespace created by the `oc.SetupProject()` will be removed automatically after the case running done.
-- Please avoid using `oc.SetupNamespace()` to setup the namespace because it potentially impacts other case execution in parallel.
+- Please avoid using `oc.SetNamespace()` to setup the namespace because it potentially impacts other case execution in parallel.
 - Call the `exutil.FixturePath()` function in `g.It()`, not in `g.Describe()`.
 - Output the logs as **less** as you can.
 - For `g.Describe()`, please ensure set the correct `sub-team` name .

--- a/test/extended/syncer/syncer.go
+++ b/test/extended/syncer/syncer.go
@@ -40,7 +40,7 @@ var _ = g.Describe("[area/transparent-multi-cluster]", func() {
 		mySyncer.CheckDisplayColumns(k)
 
 		g.By("# Creating workload using the BYO compute should work well")
-		myDeployment := exutil.NewDeployment(exutil.SetDeploymentNameSpace(myWs.CurrentNS))
+		myDeployment := exutil.NewDeployment(exutil.SetDeploymentNameSpace(myWs.CurrentNameSpace))
 		defer myDeployment.Clean(k)
 		myDeployment.Create(k)
 		myDeployment.WaitUntilReady(k)

--- a/test/extended/util/workspace.go
+++ b/test/extended/util/workspace.go
@@ -1,0 +1,30 @@
+package util
+
+import (
+	"fmt"
+
+	o "github.com/onsi/gomega"
+	"k8s.io/apiserver/pkg/storage/names"
+	e2e "k8s.io/kubernetes/test/e2e/framework"
+)
+
+// WorkSpace definition
+type WorkSpace struct {
+	Name             string   // WorkSpace Name                                                E.g. e2e-test-kcp-workspace-xxxxx
+	CurrentNameSpace string   // The latest workSpace's namespace created by SetupNameSpace()  E.g. e2e-ns-kcp-workspace-xxxxx
+	Namespaces       []string // WorkSpace's Namespaces created by SetupNameSpace()            E.g. e2e-ns-kcp-workspace-xxxxx
+	ServerURL        string   // WorkSpace ServerURL                                           E.g. https://{{kcp-service-domain}}/clusters/root:orgID:e2e-test-kcp-workspace-xxxxx
+	ParentServerURL  string   // WorkSpace ParentServerURL                                     E.g. https://{{kcp-service-domain}}/clusters/root:orgID
+}
+
+// SetNamespace creates a new namespace with
+// name in the format of "e2e-ns-"" + basename + 5Bytes random string
+func (ws *WorkSpace) SetNamespace(c *CLI) {
+	newNamespace := names.SimpleNameGenerator.GenerateName(fmt.Sprintf("e2e-ns-%s-", c.kubeFramework.BaseName))
+	e2e.Logf("Creating namespace %q", newNamespace)
+	output, errinfo := c.WithoutNamespace().WithoutKubeconf().Run("create").Args("namespace", newNamespace).Output()
+	o.Expect(errinfo).NotTo(o.HaveOccurred())
+	o.Expect(output).Should(o.ContainSubstring("created"))
+	ws.CurrentNameSpace = newNamespace
+	ws.Namespaces = append(c.currentWorkSpace.Namespaces, newNamespace)
+}


### PR DESCRIPTION
This fix refers to the suggestions proposed by @xingxingxia (https://github.com/kcp-dev/kcp-tests/pull/9#issuecomment-1253190200). It fixes the KCP workspace and global namespace conflict issues, did some house cleaning work (rename variables), and abstracted workspace as a separate package.

Test result:
```
passed: (19.7s) 2022-09-22T07:10:30 "[area/workspaces] Author:zxiao-Medium-[Serial] I can create context for a specific workspace and use it [Suite:kcp/smoke/serial]"
```

@kasturinarra @xingxingxia @Phaow, please take a look if you have time. Thanks!