### PR TITLE
Fix: couldn't get rootServer URL flake

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,11 @@ This repository holds the kcp tests that tests against the publicly available  i
   ```
 
 * Have the environment variable `KUBECONFIG` set pointing to your kcp service
+  - If your `KUBECONFIG` has multiple contexts please specific target test environment by using environment variable `E2E_TEST_CONTEXT` ( In addition, if the specified test context doesn't exist, it will try to use `kcp-stable-root` context, if `kcp-stable-root` doesn't exist either, it'll use the `current-context` in `KUBECONFIG` instead). 
+    ```console
+    $ export E2E_TEST_CONTEXT="<specific test context>"
+    ```
+  
 * Log in to the kcp service via SSO (Single Sign On)
   ```console
   $ kubectl oidc-login get-token --oidc-issuer-url=<oidc issuer url> --oidc-client-id=<oidc client ID> --oidc-redirect-url-hostname=127.0.0.1

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This repository holds the kcp tests that tests against the publicly available  i
   ```
 
 * Have the environment variable `KUBECONFIG` set pointing to your kcp service
-  - If your `KUBECONFIG` has multiple contexts please specific target test environment by using environment variable `E2E_TEST_CONTEXT` ( In addition, if the specified test context doesn't exist, it will try to use `kcp-stable-root` context, if `kcp-stable-root` doesn't exist either, it'll use the `current-context` in `KUBECONFIG` instead). 
+  - If your `KUBECONFIG` has multiple contexts please specific target test environment by using environment variable `E2E_TEST_CONTEXT` ( In addition, if the environment variable `E2E_TEST_CONTEXT` doesn't exist, it will try to use `kcp-stable-root` context, if `kcp-stable-root` doesn't exist either, it'll use the `current-context` in `KUBECONFIG` instead). 
     ```console
     $ export E2E_TEST_CONTEXT="<specific test context>"
     ```

--- a/test/extended/util/kcp_common.go
+++ b/test/extended/util/kcp_common.go
@@ -41,7 +41,7 @@ func StrSliceContainsDuplicate(strings []string) bool {
 	return false
 }
 
-// StrSliceIntersect use for none dupulicate elements slice intersect
+// StrSliceIntersect use for none duplicate elements slice intersect
 func StrSliceIntersect(slice1, slice2 []string) []string {
 	m := make(map[string]int)
 	sliceResult := make([]string, 0)


### PR DESCRIPTION
## Fix: couldn't get rootServer URL flake
**[Bug: Cannot execute smoke cases until in home workspaces](https://github.com/kcp-dev/kcp-tests/issues/17)**
**Root cause**
When `kubeconfig` don't has specified context by env var `E2E_TEST_CONTEXT` and `workspace.kcp.dev/current` and `kcp-stable` context not exists may get rootServerURL failed.
```
[knarra@knarra kcp-tests]$ ./bin/kcp-tests run all --dry-run | grep "Multi levels workspaces lifecycle should work" | ./bin/kcp-tests run -f -
INFO Sep 20 21:46:53.878: serverURL is
INFO Sep 20 21:46:54.891: Error running /bin/kubectl get workspace/~ --server= -o=jsonpath={.status.URL}:
Error from server (NotFound): clusterworkspaces.tenancy.kcp.dev "~" not found
INFO Sep 20 21:46:54.891: Getting home workspace server failed: "exit status 1"
```
**Fix Solution**
Only use the env var `E2E_TEST_CONTEXT` specific test environment whatever current context is, if env var `E2E_TEST_CONTEXT`  not exist use kcp-stable-root context, if kcp-stable-root also not exist use the current-context .

### Local Test Record
<pre>
$ ./bin/kcp-tests run all 
</pre>
```
# Test stable env
$ ./bin/kcp-tests run all 
started: (0/1/5) "[area/apiexports] Author:pewang-Critical-[Smoke] Verify APIBinding working with personal workspace [Suite:kcp/smoke/parallel/minimal]"

started: (0/2/5) "[area/transparent-multi-cluster] Author:pewang-Critical-[Smoke][BYO] Validate creating, modifying and deleting a deployment from KCP get synced to the pcluster [Suite:kcp/smoke/parallel/minimal]"

started: (0/3/5) "[area/common-version] Author:knarra-Medium-[Smoke] Checking kcp server version should display correctly [Suite:kcp/smoke/parallel/minimal]"

passed: (16.4s) 2022-10-10T10:19:47 "[area/common-version] Author:knarra-Medium-[Smoke] Checking kcp server version should display correctly [Suite:kcp/smoke/parallel/minimal]"

started: (0/4/5) "[area/workspaces] Author:pewang-Medium-[Smoke] Multi levels workspaces lifecycle should work [Suite:kcp/smoke/parallel/minimal]"

passed: (32.9s) 2022-10-10T10:20:04 "[area/apiexports] Author:pewang-Critical-[Smoke] Verify APIBinding working with personal workspace [Suite:kcp/smoke/parallel/minimal]"

passed: (1m30s) 2022-10-10T10:21:01 "[area/transparent-multi-cluster] Author:pewang-Critical-[Smoke][BYO] Validate creating, modifying and deleting a deployment from KCP get synced to the pcluster [Suite:kcp/smoke/parallel/minimal]"

passed: (2m0s) 2022-10-10T10:21:47 "[area/workspaces] Author:pewang-Medium-[Smoke] Multi levels workspaces lifecycle should work [Suite:kcp/smoke/parallel/minimal]"

started: (0/5/5) "[area/workspaces] Author:zxiao-Medium-[Serial] I can create context for a specific workspace and use it [Suite:kcp/smoke/serial]"

passed: (16.2s) 2022-10-10T10:22:03 "[area/workspaces] Author:zxiao-Medium-[Serial] I can create context for a specific workspace and use it [Suite:kcp/smoke/serial]"

5 pass, 0 skip (2m32s)

# Test unstable env
$ export E2E_TEST_CONTEXT="kcp-unstable-root" 
$ ./bin/kcp-tests run all --dry-run | grep "Multi levels workspaces lifecycle should work" | ./bin/kcp-tests run -f -
started: (0/1/1) "[area/workspaces] Author:pewang-Medium-[Smoke] Multi levels workspaces lifecycle should work [Suite:kcp/smoke/parallel/minimal]"

INFO Oct 10 18:22:57.153: kube-apiserver version: v1.24.3+kcp-v0.9.0-21-g695366eec95867
INFO Oct 10 18:22:57.157: Cluster IP family: ipv4

passed: (1m42s) 2022-10-10T10:24:33 "[area/workspaces] Author:pewang-Medium-[Smoke] Multi levels workspaces lifecycle should work [Suite:kcp/smoke/parallel/minimal]"

1 pass, 0 skip (1m42s)
```
