### PR TITLE
Add using offline token login method

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,9 @@ check-code:
 pr-test:
 	python3 ./hack/pr.py
 
+login:
+	./hack/login_with_offline_token.sh
+
 # Include the library makefile
 include $(addprefix ./, bindata.mk)
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ This repository holds the kcp tests that tests against the publicly available  i
   ```console
   $ kubectl oidc-login get-token --oidc-issuer-url=<oidc issuer url> --oidc-client-id=<oidc client ID> --oidc-redirect-url-hostname=127.0.0.1
   ```
-  - For kcp services deploy with redhat sso ( Only supported kcp services deploy with redhat sso ), there's another login method called `login with offline token` that could be used, you could get an offline token ( [How to generate an offline token](https://access.redhat.com/articles/3626371#bgenerating-a-new-offline-tokenb-3) ) and log in to the kcp service by executing the following commands with out having to input credentials into the browser.
+  - For kcp services deploy with redhat sso, there's another login method called `login with offline token` that could be used, you could get an offline token ( [How to generate an offline token](https://access.redhat.com/articles/3626371#bgenerating-a-new-offline-tokenb-3) ) and log in to the kcp service by executing the following commands with out having to input credentials into the browser.
     ```console
     $ export OFFLINE_TOKEN=<YOUR_OFFLINE_TOKEN>
     $ make login

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ This repository holds the kcp tests that tests against the publicly available  i
   ```console
   $ kubectl oidc-login get-token --oidc-issuer-url=<oidc issuer url> --oidc-client-id=<oidc client ID> --oidc-redirect-url-hostname=127.0.0.1
   ```
-  - For kcp services deploy with redhat sso( **Only supported kcp services deploy with redhat sso** ), there's another login method by use `offline token`, you could get an offline token ( [How to generate an offline token](https://access.redhat.com/articles/3626371#bgenerating-a-new-offline-tokenb-3) ) and log in to the kcp service by execute the follow commands.
+  - For kcp services deploy with redhat sso( **Only supported kcp services deploy with redhat sso** ), there's another login method called `login with offline token` that could be used, you could get an offline token ( [How to generate an offline token](https://access.redhat.com/articles/3626371#bgenerating-a-new-offline-tokenb-3) ) and log in to the kcp service by executing the following commands without inputting credentials into the browser.
     ```console
     $ export OFFLINE_TOKEN=<YOUR_OFFLINE_TOKEN>
     $ make login

--- a/README.md
+++ b/README.md
@@ -25,6 +25,11 @@ This repository holds the kcp tests that tests against the publicly available  i
   ```console
   $ kubectl oidc-login get-token --oidc-issuer-url=<oidc issuer url> --oidc-client-id=<oidc client ID> --oidc-redirect-url-hostname=127.0.0.1
   ```
+  - For kcp services deploy with redhat sso( **Only supported kcp services deploy with redhat sso** ), there's another login method by use `offline token`, you could get an offline token ( [How to generate an offline token](https://access.redhat.com/articles/3626371#bgenerating-a-new-offline-tokenb-3) ) and log in to the kcp service by execute the follow commands.
+    ```console
+    $ export OFFLINE_TOKEN=<YOUR_OFFLINE_TOKEN>
+    $ make login
+    ```
 * If you would like to test BYO cases please make sure the `PCLUSTER_KUBECONFIG` environment variable is exported otherwise else all the tests related to BYO will be skipped. 
 ## Contribution 
 Below are the general steps for submitting a PR to main branch. First, you should **Fork** this repo to your own Github account.

--- a/README.md
+++ b/README.md
@@ -25,10 +25,12 @@ This repository holds the kcp tests that tests against the publicly available  i
   ```console
   $ kubectl oidc-login get-token --oidc-issuer-url=<oidc issuer url> --oidc-client-id=<oidc client ID> --oidc-redirect-url-hostname=127.0.0.1
   ```
-  - For kcp services deploy with redhat sso( **Only supported kcp services deploy with redhat sso** ), there's another login method called `login with offline token` that could be used, you could get an offline token ( [How to generate an offline token](https://access.redhat.com/articles/3626371#bgenerating-a-new-offline-tokenb-3) ) and log in to the kcp service by executing the following commands without inputting credentials into the browser.
+  - For kcp services deploy with redhat sso ( Only supported kcp services deploy with redhat sso ), there's another login method called `login with offline token` that could be used, you could get an offline token ( [How to generate an offline token](https://access.redhat.com/articles/3626371#bgenerating-a-new-offline-tokenb-3) ) and log in to the kcp service by executing the following commands with out having to input credentials into the browser.
     ```console
     $ export OFFLINE_TOKEN=<YOUR_OFFLINE_TOKEN>
     $ make login
+    ./hack/login_with_offline_token.sh
+    INFO: Log in to kcp service with "OFFLINE_TOKEN" succeed
     ```
 * If you would like to test BYO cases please make sure the `PCLUSTER_KUBECONFIG` environment variable is exported otherwise else all the tests related to BYO will be skipped. 
 ## Contribution 

--- a/hack/login_with_offline_token.sh
+++ b/hack/login_with_offline_token.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+set -o errexit
+set -o pipefail
+
+# Check the curl package exist
+if ! [ -x "$(command -v curl)" ]; then
+    echo 'Error: curl is not installed.'
+    exit 1
+fi
+
+# Check the jq package exist
+if ! [ -x "$(command -v jq)" ]; then
+    echo 'Error: jq is not installed.'
+    exit 1
+fi
+
+# The login util is only used for kcp services which deploy with redhat sso
+# Please export your OFFLINE_TOKEN before execute the util
+# https://access.redhat.com/articles/3626371#bgenerating-a-new-offline-tokenb-3
+if [ -z "$OFFLINE_TOKEN" ]; then
+	echo 'Error: Please export your OFFLINE_TOKEN before execute the util.'
+	exit 1
+fi
+
+# Get token info by SSO
+SSO_TOKEN=$(curl -s https://sso.redhat.com/auth/realms/redhat-external/protocol/openid-connect/token -d grant_type=refresh_token -d client_id=cloud-services -d refresh_token="${OFFLINE_TOKEN}" | jq .)
+REFRESH_TOKEN=$(echo "$SSO_TOKEN" | jq .refresh_token)
+ID_TOKEN=$(echo "$SSO_TOKEN" | jq .id_token)
+
+# Write the token to oidc-login cache
+echo "{\"id_token\":${ID_TOKEN},\"refresh_token\":${REFRESH_TOKEN}}" > ~/.kube/cache/oidc-login/de0b44c30948a686e739661da92d5a6bf9c6b1fb85ce4c37589e089ba03d0ec6
+echo 'INFO: Log into kcp service with "OFFLINE_TOKEN" succeed'

--- a/hack/login_with_offline_token.sh
+++ b/hack/login_with_offline_token.sh
@@ -30,4 +30,4 @@ ID_TOKEN=$(echo "$SSO_TOKEN" | jq .id_token)
 
 # Write the token to oidc-login cache
 echo "{\"id_token\":${ID_TOKEN},\"refresh_token\":${REFRESH_TOKEN}}" > ~/.kube/cache/oidc-login/de0b44c30948a686e739661da92d5a6bf9c6b1fb85ce4c37589e089ba03d0ec6
-echo 'INFO: Log into kcp service with "OFFLINE_TOKEN" succeed'
+echo 'INFO: Log in to kcp service with "OFFLINE_TOKEN" succeed'


### PR DESCRIPTION
## Add login method with offline token
This is an enhancement for login rh-sso kcp service with an offline token. It could be helpful when we execute the kcp tests in CI environments. We could use the method login the kcp service without open a browser input the username and password. 

**Test Record**
```console
wangpenghao@MacBook-Pro  ~/Upstream/kcp-tests   login-enhance  source bin/set-offline-token                    
 wangpenghao@MacBook-Pro  ~/Upstream/kcp-tests   login-enhance  make login
./hack/login_with_offline_token.sh
INFO: Log into kcp service with "OFFLINE_TOKEN" succeed
 wangpenghao@MacBook-Pro  ~/Upstream/kcp-tests   login-enhance  k get ws
NAME              TYPE           PHASE   URL
rh-sso-XXXXXX   organization   Ready   https://<domain>/clusters/root:rh-sso-XXXXXX
```
