### PR TITLE
Fix: template utils caused APIBinding case failed

### DIFF
--- a/test/extended/apibinding/apibinding_utils.go
+++ b/test/extended/apibinding/apibinding_utils.go
@@ -81,10 +81,12 @@ func (apb *APIBinding) Create(k *exutil.CLI) {
 func (apb *APIBinding) CreateAsExpectedResult(k *exutil.CLI, successFlag bool, containsMsg string) {
 	outputFile, err := exutil.StructMarshalOutputToFile(apb, apb.Metadata.Name)
 	o.Expect(err).NotTo(o.HaveOccurred())
-	msg := exutil.ApplyResourceFromTemplate(k, outputFile)
+	msg, applyErr := exutil.ApplyResourceFromTemplate(k, outputFile)
 	if successFlag {
+		o.Expect(applyErr).ShouldNot(o.HaveOccurred())
 		o.Expect(msg).Should(o.ContainSubstring(containsMsg))
 	} else {
+		o.Expect(applyErr).Should(o.HaveOccurred())
 		o.Expect(fmt.Sprint(msg)).Should(o.ContainSubstring(containsMsg))
 	}
 }

--- a/test/extended/quota/quota.go
+++ b/test/extended/quota/quota.go
@@ -29,10 +29,11 @@ var _ = g.Describe("[area/quota]", func() {
 
 		g.By("# Create quota under the current workspace")
 		quotaTemplate := exutil.FixturePath("testdata", "quota", "quota.yaml")
-		exutil.CreateResourceFromTemplateWithVariables(k, quotaTemplate, map[string]string{
+		_, err = exutil.CreateResourceFromTemplateWithVariables(k, quotaTemplate, map[string]string{
 			"NUM_CONFIGMAP": "20",
 			"NUM_SECRET":    "20",
 		})
+		o.Expect(err).NotTo(o.HaveOccurred())
 
 		g.By("Create a few secrets and configmaps in default namespace.")
 		for i := 1; i <= 21; i++ {
@@ -52,10 +53,11 @@ var _ = g.Describe("[area/quota]", func() {
 		}
 
 		g.By("# Increase the upper quota, create a few secrets and configmaps to exceed the upper limit")
-		exutil.ApplyResourceFromTemplateWithVariables(k, quotaTemplate, map[string]string{
+		_, err = exutil.ApplyResourceFromTemplateWithVariables(k, quotaTemplate, map[string]string{
 			"NUM_CONFIGMAP": "25",
 			"NUM_SECRET":    "25",
 		})
+		o.Expect(err).NotTo(o.HaveOccurred())
 
 		for i := 20; i <= 26; i++ {
 			err = k.WithoutNamespace().Run("create").Args("secret", "generic", fmt.Sprintf("e2e-quota-secret-%d", i), "--from-literal", "abcdefg='12345^&*()'").Execute()

--- a/test/extended/util/template.go
+++ b/test/extended/util/template.go
@@ -1,62 +1,58 @@
 package util
 
-import (
-	o "github.com/onsi/gomega"
-)
-
 // ApplyResourceFromTemplate apply the changes to the cluster resource.
 // For ex: ApplyResourceFromTemplate(c, "TEMPLATE_FILE")
-func ApplyResourceFromTemplate(c *CLI, filepath string) string {
+func ApplyResourceFromTemplate(c *CLI, filepath string) (string, error) {
 	return resourceFromTemplate(c, false, "", filepath, map[string]string{})
 }
 
 // ApplyResourceFromTemplateWithVariables apply the changes to the cluster resource with args.
 // For ex: ApplyResourceFromTemplateWithVariables(c, "TEMPLATE_FILE", map{"VAR_1":"VALUE_1"})
-func ApplyResourceFromTemplateWithVariables(c *CLI, filepath string, args map[string]string) string {
+func ApplyResourceFromTemplateWithVariables(c *CLI, filepath string, args map[string]string) (string, error) {
 	return resourceFromTemplate(c, false, "", filepath, args)
 }
 
 // ApplyNsResourceFromTemplate apply changes to the ns resource.
 // No need to add a namespace parameter in the template file as it can be provided as a function argument.
 // For ex: ApplyNsResourceFromTemplate(c, "NAMESPACE", "TEMPLATE_FILE")
-func ApplyNsResourceFromTemplate(c *CLI, namespace string, filepath string) string {
+func ApplyNsResourceFromTemplate(c *CLI, namespace string, filepath string) (string, error) {
 	return resourceFromTemplate(c, false, namespace, filepath, map[string]string{})
 }
 
 // ApplyNsResourceFromTemplateWithVariables apply changes to the ns resource.
 // No need to add a namespace parameter in the template file as it can be provided as a function argument.
 // For ex: ApplyNsResourceFromTemplateWithVariables(c, "NAMESPACE", "TEMPLATE_FILE", map{"VAR_1":"VALUE_1"})
-func ApplyNsResourceFromTemplateWithVariables(c *CLI, namespace string, filepath string, variables map[string]string) string {
+func ApplyNsResourceFromTemplateWithVariables(c *CLI, namespace string, filepath string, variables map[string]string) (string, error) {
 	return resourceFromTemplate(c, false, namespace, filepath, variables)
 }
 
 // CreateResourceFromTemplate create resource from the template.
 // For ex: CreateResourceFromTemplate(c, "TEMPLATE_FILE")
-func CreateResourceFromTemplate(c *CLI, filepath string) string {
+func CreateResourceFromTemplate(c *CLI, filepath string) (string, error) {
 	return resourceFromTemplate(c, true, "", filepath, map[string]string{})
 }
 
 // CreateResourceFromTemplateWithVariables create resource from the template.
 // For ex: CreateResourceFromTemplateWithVariables(c, "TEMPLATE_FILE", map{"VAR_1":"VALUE_1"})
-func CreateResourceFromTemplateWithVariables(c *CLI, filepath string, variables map[string]string) string {
+func CreateResourceFromTemplateWithVariables(c *CLI, filepath string, variables map[string]string) (string, error) {
 	return resourceFromTemplate(c, true, "", filepath, variables)
 }
 
 // CreateNsResourceFromTemplate create ns resource from the template.
 // No need to add a namespace parameter in the template file as it can be provided as a function argument.
 // For ex: CreateNsResourceFromTemplate(c, "NAMESPACE", "TEMPLATE_FILE")
-func CreateNsResourceFromTemplate(c *CLI, namespace string, filepath string) string {
+func CreateNsResourceFromTemplate(c *CLI, namespace string, filepath string) (string, error) {
 	return resourceFromTemplate(c, true, namespace, filepath, map[string]string{})
 }
 
 // CreateNsResourceFromTemplateWithVariables create ns resource from the template.
 // No need to add a namespace parameter in the template file as it can be provided as a function argument.
 // For ex: CreateNsResourceFromTemplateWithVariables(c, "NAMESPACE", "TEMPLATE_FILE", map{"VAR_1":"VALUE_1"})
-func CreateNsResourceFromTemplateWithVariables(c *CLI, namespace string, filepath string, variables map[string]string) string {
+func CreateNsResourceFromTemplateWithVariables(c *CLI, namespace string, filepath string, variables map[string]string) (string, error) {
 	return resourceFromTemplate(c, true, namespace, filepath, variables)
 }
 
-func resourceFromTemplate(c *CLI, create bool, namespace string, filepath string, variables map[string]string) string {
+func resourceFromTemplate(c *CLI, create bool, namespace string, filepath string, variables map[string]string) (string, error) {
 	if len(variables) > 0 {
 		filepath = ParseFileVariables(filepath, variables)
 	}
@@ -65,13 +61,14 @@ func resourceFromTemplate(c *CLI, create bool, namespace string, filepath string
 		parameters = append(parameters, "-n", namespace)
 	}
 
-	var err error
-	var output string
+	var (
+		err    error
+		output string
+	)
 	if create {
 		output, err = c.Run("create").Args(parameters...).Output()
 	} else {
 		output, err = c.Run("apply").Args(parameters...).Output()
 	}
-	o.Expect(err).ShouldNot(o.HaveOccurred())
-	return output
+	return output, err
 }


### PR DESCRIPTION
## Fix: template utils caused APIBinding case failed

**Root cause**
When we do some negative test the create failed is as an expected result, but @zimo-xiao 's [new utils kcp-tests/pull/19](https://github.com/kcp-dev/kcp-tests/pull/19) expected all create results are successful.

Fix Solution
Change the underlayer framework utils not process the error with assert, return it directly, in addition we could process in sub component util methods, it'll be more general.

**Test Record**
```console
$ ./bin/kcp-tests run smoke
started: (0/1/8) "[area/workspaces] Author:pewang-Medium-[Smoke] Multi levels workspaces lifecycle should work [Suite:kcp/smoke/parallel/minimal]"

started: (0/2/8) "[area/transparent-multi-cluster] Author:pewang-Critical-[Smoke][BYO] Validate creating, modifying and deleting a deployment from KCP get synced to the pcluster [Suite:kcp/smoke/parallel/minimal]"

started: (0/3/8) "[area/common-version] Author:knarra-Medium-[Smoke] Checking kcp server version should display correctly [Suite:kcp/smoke/parallel/minimal]"

passed: (13.7s) 2022-11-09T06:33:14 "[area/common-version] Author:knarra-Medium-[Smoke] Checking kcp server version should display correctly [Suite:kcp/smoke/parallel/minimal]"

started: (0/4/8) "[area/apiexports] Author:pewang-Critical-[Smoke] Verify APIBinding working with personal workspace [Suite:kcp/smoke/parallel/minimal]"

passed: (29.8s) 2022-11-09T06:33:44 "[area/apiexports] Author:pewang-Critical-[Smoke] Verify APIBinding working with personal workspace [Suite:kcp/smoke/parallel/minimal]"

passed: (1m30s) 2022-11-09T06:34:31 "[area/transparent-multi-cluster] Author:pewang-Critical-[Smoke][BYO] Validate creating, modifying and deleting a deployment from KCP get synced to the pcluster [Suite:kcp/smoke/parallel/minimal]"

passed: (1m34s) 2022-11-09T06:34:34 "[area/workspaces] Author:pewang-Medium-[Smoke] Multi levels workspaces lifecycle should work [Suite:kcp/smoke/parallel/minimal]"

started: (0/5/8) "[area/transparent-multi-cluster] Author:knarra-Critical-[Regression] Verify default placements for shared compute [Suite:kcp/smoke/parallel]"

started: (0/6/8) "[area/transparent-multi-cluster] Author:knarra-Critical-[Regression] Verify default placements for BYO [Suite:kcp/smoke/parallel]"

started: (0/7/8) "[area/quota] Author:zxiao-Critical-[API] Verify that quota works for cluster-scoped resources across all namespaces in the workspace [Suite:kcp/smoke/parallel]"

passed: (24.1s) 2022-11-09T06:34:58 "[area/transparent-multi-cluster] Author:knarra-Critical-[Regression] Verify default placements for shared compute [Suite:kcp/smoke/parallel]"

passed: (50.8s) 2022-11-09T06:35:25 "[area/transparent-multi-cluster] Author:knarra-Critical-[Regression] Verify default placements for BYO [Suite:kcp/smoke/parallel]"

passed: (1m34s) 2022-11-09T06:36:08 "[area/quota] Author:zxiao-Critical-[API] Verify that quota works for cluster-scoped resources across all namespaces in the workspace [Suite:kcp/smoke/parallel]"

started: (0/8/8) "[area/workspaces] Author:zxiao-Medium-[Serial] I can create context for a specific workspace and use it [Suite:kcp/smoke/serial]"

passed: (13.8s) 2022-11-09T06:36:22 "[area/workspaces] Author:zxiao-Medium-[Serial] I can create context for a specific workspace and use it [Suite:kcp/smoke/serial]"

8 pass, 0 skip (3m22s)
```
