### PR TITLE
Fix flakes

### DIFF
--- a/test/extended/include.go
+++ b/test/extended/include.go
@@ -6,7 +6,7 @@ import (
 	_ "github.com/kcp-dev/kcp-tests/test/extended/apibinding"
 	_ "github.com/kcp-dev/kcp-tests/test/extended/common"
 	_ "github.com/kcp-dev/kcp-tests/test/extended/placements"
-	_ "github.com/kcp-dev/kcp-tests/test/extended/syncer"
 	_ "github.com/kcp-dev/kcp-tests/test/extended/quota"
+	_ "github.com/kcp-dev/kcp-tests/test/extended/syncer"
 	_ "github.com/kcp-dev/kcp-tests/test/extended/workspacetype"
 )

--- a/test/extended/placements/placements.go
+++ b/test/extended/placements/placements.go
@@ -2,6 +2,7 @@ package placements
 
 import (
 	"os"
+	"time"
 
 	g "github.com/onsi/ginkgo"
 	o "github.com/onsi/gomega"
@@ -37,9 +38,10 @@ var _ = g.Describe("[area/transparent-multi-cluster]", func() {
 		))
 
 		g.By("# Verify that APIBinding will be annotated with workload.kcp.dev/skip-default-object-creation")
-		apiBindingAnnotation, err := k.WithoutNamespace().WithoutKubeconf().Run("get").Args("apibinding", myAPIBinding.Metadata.Name, "-o", "json").Output()
-		o.Expect(err).NotTo(o.HaveOccurred())
-		o.Expect(apiBindingAnnotation).Should(o.ContainSubstring("workload.kcp.dev/skip-default-object-creation"))
+		o.Eventually(func() string {
+			apiBindingAnnotations, _ := k.WithoutNamespace().WithoutKubeconf().Run("get").Args("apibinding", myAPIBinding.Metadata.Name, "-o", "jsonpath={.metadata.annotations}").Output()
+			return apiBindingAnnotations
+		}, 120*time.Second, 5*time.Second).Should(o.ContainSubstring("workload.kcp.dev/skip-default-object-creation"))
 
 		g.By("# Verify creating a namespace in the current workspace")
 		k.WithoutKubeconf().Run("create").Args("namespace", "test52823").Execute()
@@ -91,9 +93,10 @@ var _ = g.Describe("[area/transparent-multi-cluster]", func() {
 		))
 
 		g.By("# Verify that APIBinding will be annotated with workload.kcp.dev/skip-default-object-creation")
-		byoApiBindingAnnotation, err := k.WithoutNamespace().WithoutKubeconf().Run("get").Args("apibinding", "kubernetes", "-o", "json").Output()
-		o.Expect(err).NotTo(o.HaveOccurred())
-		o.Expect(byoApiBindingAnnotation).Should(o.ContainSubstring("workload.kcp.dev/skip-default-object-creation"))
+		o.Eventually(func() string {
+			apiBindingAnnotations, _ := k.WithoutNamespace().WithoutKubeconf().Run("get").Args("apibinding", myAPIBinding.Metadata.Name, "-o", "jsonpath={.metadata.annotations}").Output()
+			return apiBindingAnnotations
+		}, 120*time.Second, 5*time.Second).Should(o.ContainSubstring("workload.kcp.dev/skip-default-object-creation"))
 
 		g.By("# Verify creating a namespace in the current workspace")
 		k.WithoutKubeconf().Run("create").Args("namespace", "test528231").Execute()

--- a/test/extended/placements/placements.go
+++ b/test/extended/placements/placements.go
@@ -84,9 +84,9 @@ var _ = g.Describe("[area/transparent-multi-cluster]", func() {
 		mySyncer.WaitUntilReady(k)
 
 		g.By("# Verify that default placement has been created for BYO cluster")
-		default_placement_byo, err := k.WithoutNamespace().WithoutKubeconf().Run("get").Args("placement", "default", "-o", "json").Output()
+		defaultPlacementByo, err := k.WithoutNamespace().WithoutKubeconf().Run("get").Args("placement", "default", "-o", "json").Output()
 		o.Expect(err).NotTo(o.HaveOccurred())
-		o.Expect(default_placement_byo).Should(o.And(
+		o.Expect(defaultPlacementByo).Should(o.And(
 			o.ContainSubstring("locationWorkspace"),
 			o.ContainSubstring(myWs.Name),
 			o.ContainSubstring("internal.workload.kcp.dev/synctarget"),
@@ -94,7 +94,7 @@ var _ = g.Describe("[area/transparent-multi-cluster]", func() {
 
 		g.By("# Verify that APIBinding will be annotated with workload.kcp.dev/skip-default-object-creation")
 		o.Eventually(func() string {
-			apiBindingAnnotations, _ := k.WithoutNamespace().WithoutKubeconf().Run("get").Args("apibinding", myAPIBinding.Metadata.Name, "-o", "jsonpath={.metadata.annotations}").Output()
+			apiBindingAnnotations, _ := k.WithoutNamespace().WithoutKubeconf().Run("get").Args("apibinding", "kubernetes", "-o", "jsonpath={.metadata.annotations}").Output()
 			return apiBindingAnnotations
 		}, 120*time.Second, 5*time.Second).Should(o.ContainSubstring("workload.kcp.dev/skip-default-object-creation"))
 

--- a/test/extended/syncer/syncer_utils.go
+++ b/test/extended/syncer/syncer_utils.go
@@ -170,5 +170,9 @@ func (s *SyncTarget) Delete(k *exutil.CLI) {
 
 // Clean the SyncTarget resource
 func (s *SyncTarget) Clean(k *exutil.CLI) error {
+	// TODO: Temp solution for known limitation: https://github.com/kcp-dev/kcp/issues/999
+	// Need to remove after the issue solved
+	mySyncerKey, _ := k.WithoutNamespace().WithoutKubeconf().WithoutWorkSpaceServer().Run("get").Args("--server="+s.WorkSpaceServer, "synctarget", s.Name, `-o=jsonpath={.metadata.labels.internal\.workload\.kcp\.dev/key}`).Output()
+	k.AsPClusterKubeconf().WithoutNamespace().WithoutWorkSpaceServer().Run("delete").Args("ns", "-l", "internal.workload.kcp.dev/cluster="+mySyncerKey).Execute()
 	return k.WithoutNamespace().WithoutKubeconf().WithoutWorkSpaceServer().Run("delete").Args("--server="+s.WorkSpaceServer, "synctarget", s.Name).Execute()
 }

--- a/test/extended/syncer/syncer_utils.go
+++ b/test/extended/syncer/syncer_utils.go
@@ -172,7 +172,7 @@ func (s *SyncTarget) Delete(k *exutil.CLI) {
 func (s *SyncTarget) Clean(k *exutil.CLI) error {
 	// TODO: Temp solution for known limitation: https://github.com/kcp-dev/kcp/issues/999
 	// Need to remove after the issue solved
-	mySyncerKey, _ := k.WithoutNamespace().WithoutKubeconf().WithoutWorkSpaceServer().Run("get").Args("--server="+s.WorkSpaceServer, "synctarget", s.Name, `-o=jsonpath={.metadata.labels.internal\.workload\.kcp\.dev/key}`).Output()
+	mySyncerKey, _ := k.WithoutNamespace().WithoutKubeconf().Run("get").Args("--server="+s.WorkSpaceServer, "synctarget", s.Name, `-o=jsonpath={.metadata.labels.internal\.workload\.kcp\.dev/key}`).Output()
 	k.AsPClusterKubeconf().WithoutNamespace().WithoutWorkSpaceServer().Run("delete").Args("ns", "-l", "internal.workload.kcp.dev/cluster="+mySyncerKey).Execute()
 	return k.WithoutNamespace().WithoutKubeconf().WithoutWorkSpaceServer().Run("delete").Args("--server="+s.WorkSpaceServer, "synctarget", s.Name).Execute()
 }

--- a/test/extended/util/docker.go
+++ b/test/extended/util/docker.go
@@ -6,7 +6,7 @@ import (
 	dockerClient "github.com/fsouza/go-dockerclient"
 )
 
-//ListImages initiates the equivalent of a `docker images`
+// ListImages initiates the equivalent of a `docker images`
 func ListImages() ([]string, error) {
 	client, err := dockerClient.NewClientFromEnv()
 	if err != nil {
@@ -33,7 +33,7 @@ func (mte MissingTagError) Error() string {
 	return fmt.Sprintf("the tag %s passed in was invalid, and not found in the list of images returned from docker", mte.Tags)
 }
 
-//GetImageIDForTags will obtain the hexadecimal IDs for the array of human readible image tags IDs provided
+// GetImageIDForTags will obtain the hexadecimal IDs for the array of human readible image tags IDs provided
 func GetImageIDForTags(comps []string) ([]string, error) {
 	client, dcerr := dockerClient.NewClientFromEnv()
 	if dcerr != nil {


### PR DESCRIPTION
## Fix flakes

- **Case `Verify default placements for shared compute` when check the annotations need to wait util the annotation added** 
 https://coreos.slack.com/archives/C038M7TFEUF/p1668407202269269
- **Pcluster cases when we delete the syncer there still 3 namespaces left in the Pcluster**
https://coreos.slack.com/archives/C038M7TFEUF/p1663139172060519

**Test Record**
```console
$ ./bin/kcp-tests run smoke
started: (0/1/8) "[area/workspaces] Author:pewang-Medium-[Smoke] Multi levels workspaces lifecycle should work [Suite:kcp/smoke/parallel/minimal]"

started: (0/2/8) "[area/transparent-multi-cluster] Author:pewang-Critical-[Smoke][BYO] Validate creating, modifying and deleting a deployment from KCP get synced to the pcluster [Suite:kcp/smoke/parallel/minimal]"

started: (0/3/8) "[area/common-version] Author:knarra-Medium-[Smoke] Checking kcp server version should display correctly [Suite:kcp/smoke/parallel/minimal]"

passed: (9.6s) 2022-11-18T08:22:24 "[area/common-version] Author:knarra-Medium-[Smoke] Checking kcp server version should display correctly [Suite:kcp/smoke/parallel/minimal]"

started: (0/4/8) "[area/apiexports] Author:pewang-Critical-[Smoke] Verify APIBinding working with personal workspace [Suite:kcp/smoke/parallel/minimal]"

passed: (25.5s) 2022-11-18T08:22:50 "[area/apiexports] Author:pewang-Critical-[Smoke] Verify APIBinding working with personal workspace [Suite:kcp/smoke/parallel/minimal]"

passed: (1m20s) 2022-11-18T08:23:35 "[area/workspaces] Author:pewang-Medium-[Smoke] Multi levels workspaces lifecycle should work [Suite:kcp/smoke/parallel/minimal]"

passed: (1m23s) 2022-11-18T08:23:38 "[area/transparent-multi-cluster] Author:pewang-Critical-[Smoke][BYO] Validate creating, modifying and deleting a deployment from KCP get synced to the pcluster [Suite:kcp/smoke/parallel/minimal]"

started: (0/5/8) "[area/transparent-multi-cluster] Author:knarra-Critical-[Regression] Verify default placements for shared compute [Suite:kcp/smoke/parallel]"

started: (0/6/8) "[area/transparent-multi-cluster] Author:knarra-Critical-[Regression] Verify default placements for BYO [Suite:kcp/smoke/parallel]"

started: (0/7/8) "[area/quota] Author:zxiao-Critical-[API] Verify that quota works for cluster-scoped resources across all namespaces in the workspace [Suite:kcp/smoke/parallel]"

passed: (16s) 2022-11-18T08:23:54 "[area/transparent-multi-cluster] Author:knarra-Critical-[Regression] Verify default placements for shared compute [Suite:kcp/smoke/parallel]"

passed: (49.2s) 2022-11-18T08:24:27 "[area/transparent-multi-cluster] Author:knarra-Critical-[Regression] Verify default placements for BYO [Suite:kcp/smoke/parallel]"

passed: (1m17s) 2022-11-18T08:24:55 "[area/quota] Author:zxiao-Critical-[API] Verify that quota works for cluster-scoped resources across all namespaces in the workspace [Suite:kcp/smoke/parallel]"

started: (0/8/8) "[area/workspaces] Author:zxiao-Medium-[Serial] I can create context for a specific workspace and use it [Suite:kcp/smoke/serial]"

passed: (12.8s) 2022-11-18T08:25:08 "[area/workspaces] Author:zxiao-Medium-[Serial] I can create context for a specific workspace and use it [Suite:kcp/smoke/serial]"

8 pass, 0 skip (2m53s)
```
