### PR TITLE
Auto Syncer case 50878

### DIFF
--- a/test/extended/util/client.go
+++ b/test/extended/util/client.go
@@ -302,7 +302,9 @@ func (c CLI) WithoutWorkSpaceServer() *CLI {
 
 // WithoutKubeconf instructs the command should be invoked without adding --kubeconfig parameter
 func (c CLI) WithoutKubeconf() *CLI {
-	c.withoutKubeconf = true
+	if !c.asPClusterKubeconf {
+		c.withoutKubeconf = true
+	}
 	return &c
 }
 

--- a/test/extended/util/workloads.go
+++ b/test/extended/util/workloads.go
@@ -166,3 +166,18 @@ func (dep *Deployment) CheckDisplayColumns(k *CLI) {
 	attributesValues := strings.Fields(strings.TrimSpace(displayLines[1]))
 	o.Expect(len(schemaAttributes)).Should(o.Equal(len(attributesValues)))
 }
+
+// GetPclusterDeploy gets the deployment synced to pcluster object
+func (dep *Deployment) GetPclusterDeploy(k *CLI) (pDeploy *Deployment) {
+	var err error
+	pDeploy = &Deployment{
+		Name:      dep.Name,
+		Namespace: "",
+		Replicas:  dep.Replicas,
+		AppLabel:  dep.AppLabel,
+		Image:     dep.Image,
+	}
+	pDeploy.Namespace, err = k.AsPClusterKubeconf().WithoutNamespace().WithoutWorkSpaceServer().Run("get").Args("deployment", "-A", `-o=jsonpath={.items[?(@.metadata.name=="`+dep.Name+`")].metadata.namespace}`).Output()
+	o.Expect(err).NotTo(o.HaveOccurred())
+	return pDeploy
+}


### PR DESCRIPTION
## Auto synctarget test scenario
**Critical-[Smoke][BYO] Validate kcp is source of truth**
```
CaseID: 50878
Reminding myself: Update polarion
```

### Local Test Record
<pre>
$ export KUBECONFIG=XXXX
# Export the test plcuster kubeconfig
$ export PCLUSTER_KUBECONFIG=XXXX
$ ./bin/kcp-tests run all --dry-run | grep "pcluster" |./bin/kcp-tests run -f -
</pre>
**[Test log](https://privatebin.corp.redhat.com/?caa4c34e66d4b590#GUquho9Q4jUMkErbGLF5PXiPgdZDEd8Sny5hsk7wFVrv)**

### All smoke test Record
```
...
```
### FYI
As there's known issue [dev/kcp/issues/2709](https://github.com/kcp-dev/kcp/issues/2709) of kcp, so the test case couldn't execute successfully. After the issue solved, I'll retest the code and then we could merge it.
