### PR TITLE
Automate: Verify that the bind apiexport command works as expected

### DIFF
--- a/test/extended/apibinding/apibinding_utils.go
+++ b/test/extended/apibinding/apibinding_utils.go
@@ -3,6 +3,7 @@ package apibinding
 import (
 	"fmt"
 
+	g "github.com/onsi/ginkgo"
 	o "github.com/onsi/gomega"
 
 	exutil "github.com/kcp-dev/kcp-tests/test/extended/util"
@@ -99,4 +100,12 @@ func (apb *APIBinding) Delete(k *exutil.CLI) {
 // Clean the APIBinding resource
 func (apb *APIBinding) Clean(k *exutil.CLI) error {
 	return k.WithoutNamespace().WithoutKubeconf().Run("delete").Args("apibinding", apb.Metadata.Name).Execute()
+}
+
+func applyAPIBindingHack(k *exutil.CLI) {
+	// BUG: https://github.com/kcp-dev/kcp/issues/1939
+	g.By("# BUG: apply role binding hack to allow api-binding for non-admin user")
+	roleHackTemplate := exutil.FixturePath("testdata", "apibinding", "role_hack.yaml")
+	_, err := exutil.CreateResourceFromTemplate(k, roleHackTemplate)
+	o.Expect(err).NotTo(o.HaveOccurred())
 }


### PR DESCRIPTION
This test case check the basic functionalities of `kcp bind apiexport command`. It derives from test case OCP-60113. PTAL. Thanks!

Test: passed: (29s) 2023-02-16T11:41:06 "[area/apiexports] Author:zxiao-Critical-[API] Verify that the bind apiexport command works as expected [Suite:kcp/smoke/parallel]"